### PR TITLE
remove index.js from files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test": "xo && ava"
   },
   "files": [
-    "index.js",
     "cli.js"
   ],
   "keywords": [


### PR DESCRIPTION
Probably a leftover when splitting the cli and the core :).
